### PR TITLE
Add support of env var for password

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Regardless of quoting, you do *not* need to quote or escape spaces within LDAP f
 | scope | `str` | No | choices: `['base', 'level', subtree']`; default: `subtree` | Scope of the search |
 | hostname var | `str` | No | `name` | LDAP attribute to use as the inventory hostname |
 | username | `str` | No | `null` | Username to bind as. It can the distinguished name of the user, or "SHORTDOMAIN\user".  If `null`, Kerberos + GSSAPI authentication will be used.
-| password | `str` | No | `null` | Username's password. Must be defined if username is also defined. |
+| password | `str` | No | `null` | Username's password. Must be defined if username is also defined. Environment variable `ANSIBLE_AD_PLUGIN_PASSWORD`. |
 | ansible group | `str` | No | N/A | Ansible group name to assign hosts to |
 | var attribute | `str` | No | `null` | LDAP attribute to load as YAML for host-specific Ansible variables. |
 | use ad groups | `bool` | No | `True` | Add AD group memberships as Ansible host groups. |

--- a/ad.py
+++ b/ad.py
@@ -1,4 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
+import os
+
 __metaclass__ = type
 
 DOCUMENTATION = r"""
@@ -170,7 +172,7 @@ class InventoryModule(BaseInventoryPlugin):
 
     def _get_connection_args(self):
         username = self.get_option("username")
-        password = self.get_option("password")
+        password = self.get_option("password") or os.environ.get("ANSIBLE_AD_PLUGIN_PASSWORD")
 
         if username:
             if password:


### PR DESCRIPTION
The change adds support of environment variable for user's password. No need to specify password in plain text configuration file anymore.